### PR TITLE
Add github action to run go unit tests

### DIFF
--- a/.github/workflows/go-unit-test.yaml
+++ b/.github/workflows/go-unit-test.yaml
@@ -1,0 +1,12 @@
+name: go-unit-test
+on: [push]
+jobs:
+  go-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout code
+        uses: actions/checkout@v2
+      - 
+        name: Go test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GoDoc](https://godoc.org/github.com/thegreenwebfoundation/grid-intensity-go?status.svg)](http://godoc.org/github.com/thegreenwebfoundation/grid-intensity-go) ![go-unit-test](https://github.com/thegreenwebfoundation/grid-intensity-go/workflows/go-unit-test/badge.svg)
+
 # grid-intensity-go
 
 A tool written in go, designed to be integrated into kubernetes, nomad, and other schedulers, to help you factor carbon intensity into decisions about where and when to run jobs.


### PR DESCRIPTION
I've been using github actions in the exporter. I think we can use them here too for running the unit tests.

I also added a status badge for the godoc. As I think that's useful since this is a library.
