### PR TITLE
Add GoReleaser config and action

### DIFF
--- a/.github/workflows/go-releaser.yaml
+++ b/.github/workflows/go-releaser.yaml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+dist/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,13 +9,6 @@ builds:
       - linux
       - windows
       - darwin
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
 brews:
   - tap:
       owner: thegreenwebfoundation

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,36 @@
+project_name: grid-intensity
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+brews:
+  - tap:
+      owner: thegreenwebfoundation
+      name: homebrew-grid-intensity
+      token: {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}
+    homepage: https://github.com/thegreenwebfoundation/grid-intensity-go
+    description: Get carbon intensity data for electricity grids
+    license: 	Apache-2.0
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,13 @@ builds:
       - linux
       - windows
       - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
 brews:
   - tap:
       owner: thegreenwebfoundation


### PR DESCRIPTION
Towards https://github.com/thegreenwebfoundation/grid-intensity-go/issues/12

Adds the GoReleaser config and GitHub Action. To create a new release you push a new tag.

```
git tag -a v0.1.0 -m "First release"
git push origin v0.1.0
```

It will build the binaries and create a github release. There is still some permissions foo to sort out to securely publish to the brew repo. See https://github.com/thegreenwebfoundation/grid-intensity-go/pull/15#discussion_r898057113

