### PR TITLE
Update README and ensure CLI and examples cover all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tool written in Go, designed to be integrated into Kubernetes, Nomad, and othe
 The tool has 3 components.
 
 - The `grid-intensity` CLI for interacting with carbon intensity data.
-- A Prometheus exporter with carbon intensity metrics that can be deployed via
+- A [Prometheus](https://prometheus.io/) exporter with carbon intensity metrics that can be deployed via
 Docker, Nomad, or Kubernetes.
 - A Go library that can be integrated into your Go code.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ We call this the fuel mix, and this fuel mix can impact on the carbon intensity 
 
 Because the fuel mix will be different depending when and where you run your code, you can influence the carbon intensity of the code you write by moving it through time and space - either by making it run when the grid is greener, or making it run where it's greener, like a CDN running on green power.
 
+## Inspired By
+
+This tool builds on research and tools developed from across the sustainable software community. 
+
+### Articles
+
+- A carbon aware internet - Branch magazine - https://branch.climateaction.tech/issues/issue-2/a-carbon-aware-internet/
+- Carbon Aware Kubernetes - https://devblogs.microsoft.com/sustainable-software/carbon-aware-kubernetes/
+- Clean energy technologies threaten to overwhelm the grid. Here’s how it can adapt. - https://www.vox.com/energy-and-environment/2018/11/30/17868620/renewable-energy-power-grid-architecture
+
+### Papers
+
+- A Tale of Two Visions: Designing a Decentralized Transactive Electric System - https://ieeexplore.ieee.org/document/7452738
+- Cucumber: Renewable-Aware Admission Control for Delay-Tolerant Cloud and Edge Workloads - https://arxiv.org/abs/2205.02895 
+- The carbon aware scheduler - https://pypi.org/project/carbon-aware-scheduler/
+- Let's Wait Awhile: How Temporal Workload Shifting Can Reduce Carbon Emissions in the Cloud - https://arxiv.org/abs/2110.13234
+
+### Tools
+
+- Carbon Aware Nomad - experimental branch - https://github.com/hashicorp/nomad/blob/h-carbon-meta/CARBON.md
+- Carbon Explorer - https://github.com/facebookresearch/CarbonExplorer/
+- Scaphandre - https://github.com/hubblo-org/scaphandre
+- Solar Protocol - http://solarprotocol.net/
+
 ## Installing
 
 - Install via [brew](https://brew.sh/).
@@ -73,7 +97,7 @@ $ grid-intensity --provider carbonintensity.org.uk --region UK
 }
 ```
 
-See providers section for how to configure other providers.
+The [providers](#providers) section shows how to configure other providers.
 
 ## grid-intensity exporter
 
@@ -180,3 +204,6 @@ WATT_TIME_USER=your-user \
 WATT_TIME_PASSWORD=your-password \
 grid-intensity --provider=watttime.org --region=CAISO_NORTH
 ```
+
+## Inspired By
+

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ This tool builds on research and tools developed from across the sustainable sof
 ### Papers
 
 - A Tale of Two Visions: Designing a Decentralized Transactive Electric System - https://ieeexplore.ieee.org/document/7452738
+- Carbon Explorer - https://github.com/facebookresearch/CarbonExplorer/
 - Cucumber: Renewable-Aware Admission Control for Delay-Tolerant Cloud and Edge Workloads - https://arxiv.org/abs/2205.02895 
 - Let's Wait Awhile: How Temporal Workload Shifting Can Reduce Carbon Emissions in the Cloud - https://arxiv.org/abs/2110.13234
 
 ### Tools
 
 - Carbon Aware Nomad - experimental branch - https://github.com/hashicorp/nomad/blob/h-carbon-meta/CARBON.md
-- Carbon Explorer - https://github.com/facebookresearch/CarbonExplorer/
 - Cloud Carbon Footprint - https://www.cloudcarbonfootprint.org/
 - Scaphandre - https://github.com/hubblo-org/scaphandre
 - Solar Protocol - http://solarprotocol.net/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This tool builds on research and tools developed from across the sustainable sof
 
 - Carbon Aware Nomad - experimental branch - https://github.com/hashicorp/nomad/blob/h-carbon-meta/CARBON.md
 - Carbon Explorer - https://github.com/facebookresearch/CarbonExplorer/
+- Cloud Carbon Footprint - https://www.cloudcarbonfootprint.org/
 - Scaphandre - https://github.com/hubblo-org/scaphandre
 - Solar Protocol - http://solarprotocol.net/
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This tool builds on research and tools developed from across the sustainable sof
 
 - A Tale of Two Visions: Designing a Decentralized Transactive Electric System - https://ieeexplore.ieee.org/document/7452738
 - Cucumber: Renewable-Aware Admission Control for Delay-Tolerant Cloud and Edge Workloads - https://arxiv.org/abs/2205.02895 
-- The carbon aware scheduler - https://pypi.org/project/carbon-aware-scheduler/
 - Let's Wait Awhile: How Temporal Workload Shifting Can Reduce Carbon Emissions in the Cloud - https://arxiv.org/abs/2110.13234
 
 ### Tools
@@ -45,6 +44,7 @@ This tool builds on research and tools developed from across the sustainable sof
 - Cloud Carbon Footprint - https://www.cloudcarbonfootprint.org/
 - Scaphandre - https://github.com/hubblo-org/scaphandre
 - Solar Protocol - http://solarprotocol.net/
+- The carbon aware scheduler - https://pypi.org/project/carbon-aware-scheduler/
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-[![GoDoc](https://godoc.org/github.com/thegreenwebfoundation/grid-intensity-go?status.svg)](http://godoc.org/github.com/thegreenwebfoundation/grid-intensity-go) ![go-unit-test](https://github.com/thegreenwebfoundation/grid-intensity-go/workflows/go-unit-test/badge.svg)
+[![GoDoc](https://godoc.org/github.com/thegreenwebfoundation/grid-intensity-go?status.svg)](http://godoc.org/github.com/thegreenwebfoundation/grid-intensity-go) ![go-unit-test](https://github.com/thegreenwebfoundation/grid-intensity-go/workflows/go-unit-test/badge.svg) ![docker](https://github.com/thegreenwebfoundation/grid-intensity-go/workflows/docker-integration-test/badge.svg) ![kubernetes](https://github.com/thegreenwebfoundation/grid-intensity-go/workflows/kubernetes-integration-test/badge.svg) ![nomad](https://github.com/thegreenwebfoundation/grid-intensity-go/workflows/nomad-integration-test/badge.svg)
 
 # grid-intensity-go
 
-A tool written in go, designed to be integrated into kubernetes, nomad, and other schedulers, to help you factor carbon intensity into decisions about where and when to run jobs.
+A tool written in Go, designed to be integrated into Kubernetes, Nomad, and other schedulers, to help you factor carbon intensity into decisions about where and when to run jobs.
+
+The tool has 3 components.
+
+- The `grid-intensity` CLI for interacting with carbon intensity data.
+- A Prometheus exporter with carbon intensity metrics that can be deployed via
+Docker, Nomad, or Kubernetes.
+- A Go library that can be integrated into your Go code.
 
 ## Background
 
@@ -14,7 +21,162 @@ We call this the fuel mix, and this fuel mix can impact on the carbon intensity 
 
 Because the fuel mix will be different depending when and where you run your code, you can influence the carbon intensity of the code you write by moving it through time and space - either by making it run when the grid is greener, or making it run where it's greener, like a CDN running on green power.
 
-## Data
+## Installing
 
-Carbon intensity data from [Ember](https://ember-climate.org/), in accordance of their licensing - [CC-BY-SA 4.0](https://ember-climate.org/creative-commons/
-)
+- Install via [brew](https://brew.sh/).
+
+```sh
+brew install thegreenwebfoundation/carbon-aware-tools/grid-intensity
+```
+
+- Install via curl (feel free to do due diligence and check the [script](https://github.com/thegreenwebfoundation/grid-intensity-go/blob/main/install.sh) first).
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/thegreenwebfoundation/grid-intensity-go/install-script/install.sh | sudo sh
+```
+
+- Fetch a binary release from the [releases](https://github.com/thegreenwebfoundation/grid-intensity-go/releases) page.
+
+## grid-intensity CLI
+
+The CLI allows you to interact with carbon intensity data from multiple providers.
+
+```sh
+$ grid-intensity
+Provider ember-climate.org needs an ISO country code as a region parameter.
+ESP detected from your locale.
+ESP
+{
+	"country_code_iso_2": "ES",
+	"country_code_iso_3": "ESP",
+	"country_or_region": "Spain",
+	"year": 2021,
+	"latest_year": 2021,
+	"emissions_intensity_gco2_per_kwh": 193.737
+}
+```
+
+The `--provider` and `--region` flags allow you to select other providers and regions.
+You can also set the `GRID_INTENSITY_PROVIDER` and `GRID_INTENSITY_REGION` environment
+variables or edit the config file at `~/.config/grid-intensity/config.yaml`.
+
+```sh
+$ grid-intensity --provider carbonintensity.org.uk --region UK
+{
+	"from": "2022-07-14T14:30Z",
+	"to": "2022-07-14T15:00Z",
+	"intensity": {
+		"forecast": 184,
+		"actual": 194,
+		"index": "moderate"
+	}
+}
+```
+
+See providers section for how to configure other providers.
+
+## grid-intensity exporter
+
+The `exporter` subcommand starts the prometheus exporter on port 8000.
+
+```sh
+$ grid-intensity exporter --provider ember-climate.org --region FR
+Using provider "ember-climate.org" with region "FR"
+Metrics available at :8000/metrics
+```
+
+View the metrics with curl.
+
+```
+$ curl -s http://localhost:8000/metrics | grep grid
+# HELP grid_intensity_carbon_average Average carbon intensity for the electricity grid in this region.
+# TYPE grid_intensity_carbon_average gauge
+grid_intensity_carbon_average{provider="ember-climate.org",region="FR",units="gCO2 per kWh"} 67.781
+```
+
+### Docker Image
+
+Build the docker image to deploy the exporter.
+
+```sh
+CGO_ENABLED=0 GOOS=linux go build -o grid-intensity .
+docker build -t thegreenwebfoundation/grid-intensity:latest .
+```
+
+### Kubernetes
+
+Install the [helm](https://helm.sh/) chart in [/helm/grid-intensity-exporter](https://github.com/thegreenwebfoundation/grid-intensity-go/tree/main/helm/grid-intensity-exporter).
+Needs the Docker image to be available in the cluster.
+
+```sh
+helm install --set gridIntensity.region=FR grid-intensity-exporter helm/grid-intensity-exporter
+```
+
+### Nomad
+
+Edit the Nomad job in [/nomad/grid-intensity-exporter.nomad](https://github.com/thegreenwebfoundation/grid-intensity-go/blob/main/nomad/grid-intensity-exporter.nomad) to set the
+env vars `GRID_INTENSITY_REGION` and `GRID_INTENSITY_PROVIDER`
+
+Start the Nomad job. Needs the Docker image to be available in the cluster.
+
+```sh
+nomad run ./nomad/grid-intensity-exporter.nomad
+```
+
+## grid-intensity-go library
+
+See the [/examples/](https://github.com/thegreenwebfoundation/grid-intensity-go/tree/main/examples) 
+directory for examples of how to integrate each provider.
+
+## Providers
+
+Currently these providers of carbon intensity data are integrated. If you would like
+us to integrate more providers please open an [issue](https://github.com/thegreenwebfoundation/grid-intensity-go/issues).
+
+### CarbonIntensity.org.uk
+
+UK Carbon Intensity API https://carbonintensity.org.uk/ this is a public API
+and the only region supported is `UK`.
+
+```sh
+grid-intensity --provider=carbonintensity.org.uk --region=UK
+```
+
+### ElectricityMap.org
+
+[Electricity Map](https://app.electricitymaps.com/map) have carbon intensity data
+from multiple sources. You need an [API token](https://static.electricitymap.org/api/docs/index.html#authentication)
+to use the API.
+
+The `region` parameter needs to be set to a zone present in the public [zones](https://static.electricitymap.org/api/docs/index.html#zones) endpoint.
+
+```sh
+ELECTRICITY_MAP_API_TOKEN=your-token \
+grid-intensity --provider=electricitymap.org --region=IN-KA
+```
+
+### Ember-Climate.org
+
+Carbon intensity data from [Ember](https://ember-climate.org/), is embedded in the binary
+in accordance with their licensing - [CC-BY-SA 4.0](https://ember-climate.org/creative-commons/)
+
+```sh
+grid-intensity --provider=ember-climate.org --region=DE
+```
+
+The `region` parameter should be set to a 2 or 3 char ISO country code.
+
+### WattTime.org
+
+[WattTime](https://www.watttime.org/) have carbon intensity data from multiple sources.
+You need to [register](https://www.watttime.org/api-documentation/#authentication) to use the API.
+
+The `region` parameter should be set to a supported region. The `/ba-from-loc`
+endpoint allows you to provide a latitude and longitude. See the [docs](https://www.watttime.org/api-documentation/#determine-grid-region) for more details.
+
+
+```sh
+WATT_TIME_USER=your-user \
+WATT_TIME_PASSWORD=your-password \
+grid-intensity --provider=watttime.org --region=CAISO_NORTH
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/thegreenwebfoundation/grid-intensity-go/carbonintensity"
+	"github.com/thegreenwebfoundation/grid-intensity-go/electricitymap"
 	"github.com/thegreenwebfoundation/grid-intensity-go/ember"
 	"github.com/thegreenwebfoundation/grid-intensity-go/watttime"
 )
@@ -86,6 +87,32 @@ func getCarbonIntensityOrgUK(ctx context.Context, region string) error {
 	}
 
 	fmt.Println(string(bytes))
+	return nil
+}
+
+func getElectricityMapGridIntensity(ctx context.Context, region string) error {
+	apiToken := os.Getenv(electricityMapAPITokenEnvVar)
+	if apiToken == "" {
+		return fmt.Errorf("%q env var must be set", electricityMapAPITokenEnvVar)
+	}
+
+	c, err := electricitymap.New(apiToken)
+	if err != nil {
+		return fmt.Errorf("could not make provider %v", err)
+	}
+
+	result, err := c.GetCarbonIntensityData(ctx, region)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.MarshalIndent(result, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(bytes))
+
 	return nil
 }
 
@@ -185,6 +212,11 @@ func runRoot() error {
 		viper.Set(region, regionCode)
 
 		err = getCarbonIntensityOrgUK(ctx, regionCode)
+		if err != nil {
+			return err
+		}
+	case electricitymap.ProviderName:
+		err = getElectricityMapGridIntensity(ctx, regionCode)
 		if err != nil {
 			return err
 		}

--- a/electricitymap/schema.go
+++ b/electricitymap/schema.go
@@ -1,6 +1,6 @@
 package electricitymap
 
-type CarbonIntensityResp struct {
+type CarbonIntensityData struct {
 	Zone            string  `json:"zone"`
 	CarbonIntensity float64 `json:"carbonIntensity"`
 }

--- a/examples/watttime/main.go
+++ b/examples/watttime/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/thegreenwebfoundation/grid-intensity-go/watttime"
+)
+
+func main() {
+	// Register via the API
+	// https://www.watttime.org/api-documentation/#register-new-user
+	wattTimeUser := "your-user"
+	wattTimePassword := "your-password"
+
+	c, err := watttime.New(wattTimeUser, wattTimePassword)
+	if err != nil {
+		log.Fatalln("could not make provider", err)
+	}
+	a, err := c.GetCarbonIntensity(context.Background(), "CAISO_NORTH")
+	log.Println(a, err)
+}


### PR DESCRIPTION
Prior to cutting the 0.3.0 release this updates the README so it covers that this repo now provides 3 components

- CLI
- Prometheus exporter
- Go library

It also adds the missing ElectricityMap provider to the CLI and the WattTime example for the Go library.

My thinking is a lot of this content can move to the developer tools website. My hope is this gives us the bare bones that we can then improve on.

For example this doesn't explain the difference between the marginal emissions provided by WattTime and the average emissions provided by the other providers.
