### PR TITLE
Rename provider names and add provider list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also set the `GRID_INTENSITY_PROVIDER` and `GRID_INTENSITY_REGION` envir
 variables or edit the config file at `~/.config/grid-intensity/config.yaml`.
 
 ```sh
-$ grid-intensity --provider carbonintensity.org.uk --region UK
+$ grid-intensity --provider CarbonIntensityOrgUK --region UK
 {
 	"from": "2022-07-14T14:30Z",
 	"to": "2022-07-14T15:00Z",
@@ -105,8 +105,8 @@ The [providers](#providers) section shows how to configure other providers.
 The `exporter` subcommand starts the prometheus exporter on port 8000.
 
 ```sh
-$ grid-intensity exporter --provider ember-climate.org --region FR
-Using provider "ember-climate.org" with region "FR"
+$ grid-intensity exporter --provider Ember --region FR
+Using provider "Ember" with region "FR"
 Metrics available at :8000/metrics
 ```
 
@@ -116,7 +116,7 @@ View the metrics with curl.
 $ curl -s http://localhost:8000/metrics | grep grid
 # HELP grid_intensity_carbon_average Average carbon intensity for the electricity grid in this region.
 # TYPE grid_intensity_carbon_average gauge
-grid_intensity_carbon_average{provider="ember-climate.org",region="FR",units="gCO2 per kWh"} 67.781
+grid_intensity_carbon_average{provider="Ember",region="FR",units="gCO2 per kWh"} 67.781
 ```
 
 ### Docker Image
@@ -164,7 +164,7 @@ UK Carbon Intensity API https://carbonintensity.org.uk/ this is a public API
 and the only region supported is `UK`.
 
 ```sh
-grid-intensity --provider=carbonintensity.org.uk --region=UK
+grid-intensity --provider=CarbonIntensityOrgUK --region=UK
 ```
 
 ### ElectricityMap.org
@@ -177,7 +177,7 @@ The `region` parameter needs to be set to a zone present in the public [zones](h
 
 ```sh
 ELECTRICITY_MAP_API_TOKEN=your-token \
-grid-intensity --provider=electricitymap.org --region=IN-KA
+grid-intensity --provider=ElectricityMap --region=IN-KA
 ```
 
 ### Ember-Climate.org
@@ -186,7 +186,7 @@ Carbon intensity data from [Ember](https://ember-climate.org/), is embedded in t
 in accordance with their licensing - [CC-BY-SA 4.0](https://ember-climate.org/creative-commons/)
 
 ```sh
-grid-intensity --provider=ember-climate.org --region=DE
+grid-intensity --provider=Ember --region=DE
 ```
 
 The `region` parameter should be set to a 2 or 3 char ISO country code.
@@ -203,5 +203,5 @@ endpoint allows you to provide a latitude and longitude. See the [docs](https://
 ```sh
 WATT_TIME_USER=your-user \
 WATT_TIME_PASSWORD=your-password \
-grid-intensity --provider=watttime.org --region=CAISO_NORTH
+grid-intensity --provider=WattTime --region=CAISO_NORTH
 ```

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -75,7 +75,7 @@ This can be used to make your software carbon aware so it runs at times when
 the grid is greener or at locations where carbon intensity is lower.
 
 	grid-intensity exporter --provider PROVIDER --region ARG
-	grid-intensity exporter -p ember-climate.org -r BOL`,
+	grid-intensity exporter -p Ember -r BOL`,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runExporter()
 			if err != nil {

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/thegreenwebfoundation/grid-intensity-go/pkg/provider"
 )
@@ -21,6 +22,12 @@ const (
 )
 
 func init() {
+	exporterCmd.Flags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
+	exporterCmd.Flags().StringP(regionKey, "r", "", "Region code for provider")
+
+	viper.BindPFlag(providerKey, exporterCmd.Flags().Lookup(providerKey))
+	viper.BindPFlag(regionKey, exporterCmd.Flags().Lookup(regionKey))
+
 	rootCmd.AddCommand(exporterCmd)
 }
 

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(providerCmd)
+}
+
+var (
+	providerCmd = &cobra.Command{
+		Use:   "provider",
+		Short: "Details about providers of carbon intensity data",
+		Long:  "Details about providers of carbon intensity data",
+	}
+)

--- a/cmd/provider_list.go
+++ b/cmd/provider_list.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+
+	"github.com/thegreenwebfoundation/grid-intensity-go/pkg/provider"
+)
+
+func init() {
+	providerCmd.AddCommand(providerListCmd)
+}
+
+var (
+	providerListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List supported providers of carbon intensity data",
+		Long: `List all supported providers of carbon intensity data
+for electricity grids.
+
+	grid-intensity provider list`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := runProviderList()
+			if err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+)
+
+func runProviderList() error {
+	providers := provider.GetProviderDetails()
+
+	tbl := table.New("NAME", "URL")
+
+	for _, p := range providers {
+		tbl.AddRow(p.Name, p.URL)
+	}
+
+	tbl.Print()
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,12 +54,11 @@ func Execute() {
 }
 
 func init() {
-	// Use persistent flags so they are available to all subcommands.
-	rootCmd.PersistentFlags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
-	rootCmd.PersistentFlags().StringP(regionKey, "r", "", "Region code for provider")
+	rootCmd.Flags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
+	rootCmd.Flags().StringP(regionKey, "r", "", "Region code for provider")
 
-	viper.BindPFlag(providerKey, rootCmd.PersistentFlags().Lookup(providerKey))
-	viper.BindPFlag(regionKey, rootCmd.PersistentFlags().Lookup(regionKey))
+	viper.BindPFlag(providerKey, rootCmd.Flags().Lookup(providerKey))
+	viper.BindPFlag(regionKey, rootCmd.Flags().Lookup(regionKey))
 
 	// Also support environment variables.
 	viper.SetEnvPrefix("grid_intensity")

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/prometheus/client_golang v1.12.2
+	github.com/rodaine/table v1.0.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -357,6 +359,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/rodaine/table v1.0.1 h1:U/VwCnUxlVYxw8+NJiLIuCxA/xa6jL38MY3FYysVWWQ=
+github.com/rodaine/table v1.0.1/go.mod h1:UVEtfBsflpeEcD56nF4F5AocNFta0ZuolpSVdPtlmP4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=

--- a/helm/grid-intensity-exporter/values.yaml
+++ b/helm/grid-intensity-exporter/values.yaml
@@ -1,6 +1,6 @@
 # This is the default provider with the Ember 2021 dataset.
 gridIntensity:
-  provider: ember-climate.org
+  provider: Ember
   region: GBR
 
 image:
@@ -12,21 +12,21 @@ image:
 # supports the UK region.
 #
 # gridIntensity:
-#   provider: carbonintensity.org.uk
+#   provider: CarbonIntensityOrgUK
 #   region: UK
 
 # ElectricityMap provider supports multiple countries but you will need to set
 # an API key in electricityMap.apiToken 
 #
 # gridIntensity:
-#   provider: electricitymap.org
+#   provider: ElectricityMap
 #   region: IN-KA
 
 # WattTime provider supports multiple countries but you will need to set an API
 # user in wattTime.apiUser and wattTime.apiPassword
 #
 # gridIntensity:
-#   provider: watttime.org
+#   provider: WattTime
 #   region: CAISO_NORTH
 
 # Get API token from https://electricitymaps.com/

--- a/integration/test/exporter/metric_test.go
+++ b/integration/test/exporter/metric_test.go
@@ -48,7 +48,7 @@ func Test_GridIntensityMetric(t *testing.T) {
 		t.Fatalf("expected nil got %v", err)
 	}
 
-	expectedMetricText := "grid_intensity_carbon_average{provider=\"ember-climate.org\",region=\"GBR\",units=\"gCO2e per kWh\"}"
+	expectedMetricText := "grid_intensity_carbon_average{provider=\"Ember\",region=\"GBR\",units=\"gCO2e per kWh\"}"
 
 	if !strings.Contains(metrics, expectedMetricText) {
 		t.Fatalf("expected metric text %q not found got %q", expectedMetricText, metrics)

--- a/nomad/grid-intensity-exporter.nomad
+++ b/nomad/grid-intensity-exporter.nomad
@@ -35,7 +35,7 @@ job "grid-intensity-exporter" {
       }
 
       env {
-        GRID_INTENSITY_PROVIDER = "ember-climate.org"
+        GRID_INTENSITY_PROVIDER = "Ember"
         GRID_INTENSITY_REGION = "GBR"
       }
     }

--- a/pkg/provider/carbon_intensity_uk_test.go
+++ b/pkg/provider/carbon_intensity_uk_test.go
@@ -48,7 +48,7 @@ func Test_CarbonIntensityUK_SimpleRequest(t *testing.T) {
 
 	expected := []CarbonIntensity{
 		{
-			Provider:      "carbonintensity.org.uk",
+			Provider:      "CarbonIntensityOrgUK",
 			EmissionsType: "average",
 			MetricType:    "absolute",
 			Region:        "UK",

--- a/pkg/provider/electricity_map_test.go
+++ b/pkg/provider/electricity_map_test.go
@@ -44,7 +44,7 @@ func Test_ElectricityMap_SimpleRequest(t *testing.T) {
 		{
 			EmissionsType: "average",
 			MetricType:    "absolute",
-			Provider:      "electricitymap.org",
+			Provider:      "ElectricityMap",
 			Region:        "IN-KA",
 			Units:         "gCO2e per kWh",
 			ValidFrom:     time.Date(2020, 1, 1, 0, 0, 1, 0, time.UTC),

--- a/pkg/provider/ember_test.go
+++ b/pkg/provider/ember_test.go
@@ -25,7 +25,7 @@ func Test_GetGridIntensityForCountry(t *testing.T) {
 				{
 					EmissionsType: "average",
 					MetricType:    "absolute",
-					Provider:      "ember-climate.org",
+					Provider:      "Ember",
 					Region:        "ESP",
 					Units:         "gCO2e per kWh",
 					ValidFrom:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -41,7 +41,7 @@ func Test_GetGridIntensityForCountry(t *testing.T) {
 				{
 					EmissionsType: "average",
 					MetricType:    "absolute",
-					Provider:      "ember-climate.org",
+					Provider:      "Ember",
 					Region:        "ES",
 					Units:         "gCO2e per kWh",
 					ValidFrom:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -57,7 +57,7 @@ func Test_GetGridIntensityForCountry(t *testing.T) {
 				{
 					EmissionsType: "average",
 					MetricType:    "absolute",
-					Provider:      "ember-climate.org",
+					Provider:      "Ember",
 					Region:        "GBR",
 					Units:         "gCO2e per kWh",
 					ValidFrom:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -20,10 +20,10 @@ const (
 	Percent         = "percent"
 
 	// Supported providers
-	CarbonIntensityOrgUK = "carbonintensity.org.uk"
-	Ember                = "ember-climate.org"
-	ElectricityMap       = "electricitymap.org"
-	WattTime             = "watttime.org"
+	CarbonIntensityOrgUK = "CarbonIntensityOrgUK"
+	Ember                = "Ember"
+	ElectricityMap       = "ElectricityMap"
+	WattTime             = "WattTime"
 )
 
 type CarbonIntensity struct {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -21,8 +21,8 @@ const (
 
 	// Supported providers
 	CarbonIntensityOrgUK = "CarbonIntensityOrgUK"
-	Ember                = "Ember"
 	ElectricityMap       = "ElectricityMap"
+	Ember                = "Ember"
 	WattTime             = "WattTime"
 )
 
@@ -37,6 +37,32 @@ type CarbonIntensity struct {
 	Value         float64   `json:"value"`
 }
 
+type Details struct {
+	Name string
+	URL  string
+}
+
 type Interface interface {
 	GetCarbonIntensity(ctx context.Context, region string) ([]CarbonIntensity, error)
+}
+
+func GetProviderDetails() []Details {
+	return []Details{
+		{
+			Name: CarbonIntensityOrgUK,
+			URL:  "carbonintensity.org.uk",
+		},
+		{
+			Name: ElectricityMap,
+			URL:  "electricitymap.org",
+		},
+		{
+			Name: Ember,
+			URL:  "ember-climate.org",
+		},
+		{
+			Name: WattTime,
+			URL:  "watttime.org",
+		},
+	}
 }

--- a/pkg/provider/watt_time_test.go
+++ b/pkg/provider/watt_time_test.go
@@ -59,7 +59,7 @@ func Test_WattTime_SimpleRequest(t *testing.T) {
 		{
 			EmissionsType: "marginal",
 			MetricType:    "relative",
-			Provider:      "watttime.org",
+			Provider:      "WattTime",
 			Region:        "CAISO_NORTH",
 			Units:         "percent",
 			ValidFrom:     time.Date(2022, 7, 6, 16, 25, 0, 0, time.UTC),
@@ -69,7 +69,7 @@ func Test_WattTime_SimpleRequest(t *testing.T) {
 		{
 			EmissionsType: "marginal",
 			MetricType:    "absolute",
-			Provider:      "watttime.org",
+			Provider:      "WattTime",
 			Region:        "CAISO_NORTH",
 			Units:         "lbCO2e per MWh",
 			ValidFrom:     time.Date(2022, 7, 6, 16, 25, 0, 0, time.UTC),


### PR DESCRIPTION
Towards https://github.com/thegreenwebfoundation/grid-intensity-go/issues/45

This renames the provider names to have friendlier names instead of URLs

It also adds a new provider list command to show the supported providers.

```
go run . provider list
NAME                  URL
CarbonIntensityOrgUK  carbonintensity.org.uk
ElectricityMap        electricitymap.org
Ember                 ember-climate.org
WattTime              watttime.org
```

For now it just returns the name and URL but should we add the descriptions from the developer site?




