### PR TITLE
Bind flags in PreRun not init

### DIFF
--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -25,9 +25,6 @@ func init() {
 	exporterCmd.Flags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
 	exporterCmd.Flags().StringP(regionKey, "r", "", "Region code for provider")
 
-	viper.BindPFlag(providerKey, exporterCmd.Flags().Lookup(providerKey))
-	viper.BindPFlag(regionKey, exporterCmd.Flags().Lookup(regionKey))
-
 	rootCmd.AddCommand(exporterCmd)
 }
 
@@ -76,6 +73,10 @@ the grid is greener or at locations where carbon intensity is lower.
 
 	grid-intensity exporter --provider PROVIDER --region ARG
 	grid-intensity exporter -p Ember -r BOL`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag(providerKey, cmd.Flags().Lookup(providerKey))
+			viper.BindPFlag(regionKey, cmd.Flags().Lookup(regionKey))
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runExporter()
 			if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,10 @@ grid is greener or at locations where carbon intensity is lower.
 	grid-intensity --region ARG
 	grid-intensity -r BOL`,
 
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag(providerKey, cmd.Flags().Lookup(providerKey))
+		viper.BindPFlag(regionKey, cmd.Flags().Lookup(regionKey))
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := runRoot()
 		if err != nil {
@@ -56,9 +60,6 @@ func Execute() {
 func init() {
 	rootCmd.Flags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
 	rootCmd.Flags().StringP(regionKey, "r", "", "Region code for provider")
-
-	viper.BindPFlag(providerKey, rootCmd.Flags().Lookup(providerKey))
-	viper.BindPFlag(regionKey, rootCmd.Flags().Lookup(regionKey))
 
 	// Also support environment variables.
 	viper.SetEnvPrefix("grid_intensity")


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/thegreenwebfoundation/grid-intensity-go/pull/55 🤦‍♂️ 

Before the provider and region flags were global. Now we have to add them for each command where they are needed.
So we hit https://github.com/spf13/viper/issues/233

The fix is to bind the flags in the PreRun rather than the init function. So they are bound to the correct command.