### PR TITLE
Electricity maps auth fix

### DIFF
--- a/examples/electricitymap/main.go
+++ b/examples/electricitymap/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatalln("could not make provider", err)
 	}
 
-	res, err := e.GetCarbonIntensity(context.Background(), "IN-KA")
+	res, err := e.GetCarbonIntensity(context.Background(), "AU-SA")
 	if err != nil {
 		log.Fatalln("could not get carbon intensity", err)
 	}

--- a/pkg/provider/electricity_map.go
+++ b/pkg/provider/electricity_map.go
@@ -41,6 +41,7 @@ func NewElectricityMap(config ElectricityMapConfig) (Interface, error) {
 
 func (e *ElectricityMapClient) GetCarbonIntensity(ctx context.Context, location string) ([]CarbonIntensity, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.intensityURLWithZone(location), nil)
+	req.Header.Add("auth-token", e.token)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds the `auth-token` header for Electricity Maps API requests.

Related to issue #66 