### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,13 +9,20 @@ builds:
       - linux
       - windows
       - darwin
+
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+    - goos: windows
+      format: zip
+
 brews:
   - tap:
       owner: thegreenwebfoundation


### PR DESCRIPTION
Replacements has been removed which caused CI to fail

See https://github.com/goreleaser/goreleaser/issues/3625