### PR TITLE
Improve Go library examples

### DIFF
--- a/examples/electricitymap/main.go
+++ b/examples/electricitymap/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	// Register at https://api-portal.electricitymaps.com/
 	token := os.Getenv("ELECTRICITY_MAP_API_TOKEN")
 	if token == "" {
 		log.Fatalln("please set the env variable `ELECTRICITY_MAP_API_TOKEN`")

--- a/examples/watttime/main.go
+++ b/examples/watttime/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/thegreenwebfoundation/grid-intensity-go/pkg/provider"
 )
@@ -12,9 +13,18 @@ import (
 func main() {
 	// Register via the API
 	// https://www.watttime.org/api-documentation/#register-new-user
+	apiUser := os.Getenv("WATT_TIME_API_USER")
+	if apiUser == "" {
+		log.Fatalln("please set the env variable `WATT_TIME_API_USER`")
+	}
+	apiPassword := os.Getenv("WATT_TIME_API_PASSWORD")
+	if apiPassword != "" {
+		log.Fatalln("please set the env variable `WATT_TIME_API_PASSWORD`")
+	}
+
 	c := provider.WattTimeConfig{
-		APIUser:     "your-user",
-		APIPassword: "your-password",
+		APIUser:     apiUser,
+		APIPassword: apiPassword,
 	}
 	w, err := provider.NewWattTime(c)
 	if err != nil {


### PR DESCRIPTION
This is pretty minor but we use env vars for the ElectricityMaps example and I think we should do the same for WattTime.