### PR TITLE
Rename ElectricityMaps provider and fix for URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Rename Electricity Map provider to Electricity Maps.
+
+### Fixed
+
+- Building URLs now handles if base URL has trailing slashes or not.
+
 ## 0.5.0 2023-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,16 +168,16 @@ us to integrate more providers please open an [issue](https://github.com/thegree
 
 ### Electricity Maps
 
-[Electricity Map](https://app.electricitymaps.com/map) have carbon intensity data
+[Electricity Maps](https://app.electricitymaps.com/map) have carbon intensity data
 from multiple sources. You need to get an API token and URL from their
 [API portal](https://api-portal.electricitymaps.com/) to use the API. You can use
 their free tier for non-commercial use or sign up for a 30 day trial.
 
-The `location` parameter needs to be set to a zone present in the public [zones](https://static.electricitymap.org/api/docs/index.html#zones) endpoint.
+The `location` parameter needs to be set to a zone present in the public [zones](https://static.electricitymaps.com/api/docs/index.html#zones) endpoint.
 
 ```sh
-ELECTRICITY_MAP_API_TOKEN=your-token \
-ELECTRICITY_MAP_API_URL=https://api-access.electricitymaps.com/free-tier/ \
+ELECTRICITY_MAPS_API_TOKEN=your-token \
+ELECTRICITY_MAPS_API_URL=https://api-access.electricitymaps.com/free-tier/ \
 grid-intensity --provider=ElectricityMap --location=IN-KA
 ```
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -18,7 +18,7 @@ func getClient(providerName string, cacheFile string) (provider.Interface, error
 		if err != nil {
 			return nil, fmt.Errorf("could not make carbon intensity uk provider, %w", err)
 		}
-	case provider.ElectricityMap:
+	case provider.ElectricityMaps:
 		token := os.Getenv(electricityMapAPITokenEnvVar)
 		if token == "" {
 			return nil, fmt.Errorf("%q env var must be set", electricityMapAPITokenEnvVar)
@@ -28,13 +28,13 @@ func getClient(providerName string, cacheFile string) (provider.Interface, error
 			return nil, fmt.Errorf("%q env var must be set", electricityMapAPIURLEnvVar)
 		}
 
-		c := provider.ElectricityMapConfig{
+		c := provider.ElectricityMapsConfig{
 			APIURL: url,
 			Token:  token,
 		}
-		client, err = provider.NewElectricityMap(c)
+		client, err = provider.NewElectricityMaps(c)
 		if err != nil {
-			return nil, fmt.Errorf("could not make electricity map provider, %w", err)
+			return nil, fmt.Errorf("could not make electricity maps provider, %w", err)
 		}
 	case provider.Ember:
 		client, err = provider.NewEmber()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	electricityMapAPITokenEnvVar = "ELECTRICITY_MAP_API_TOKEN"
-	electricityMapAPIURLEnvVar   = "ELECTRICITY_MAP_API_URL"
+	electricityMapAPITokenEnvVar = "ELECTRICITY_MAPS_API_TOKEN"
+	electricityMapAPIURLEnvVar   = "ELECTRICITY_MAPS_API_URL"
 	wattTimeUserEnvVar           = "WATT_TIME_USER"
 	wattTimePasswordEnvVar       = "WATT_TIME_PASSWORD"
 )

--- a/examples/electricitymap/main.go
+++ b/examples/electricitymap/main.go
@@ -12,20 +12,20 @@ import (
 
 func main() {
 	// Register at https://api-portal.electricitymaps.com/
-	token := os.Getenv("ELECTRICITY_MAP_API_TOKEN")
+	token := os.Getenv("ELECTRICITY_MAPS_API_TOKEN")
 	if token == "" {
-		log.Fatalln("please set the env variable `ELECTRICITY_MAP_API_TOKEN`")
+		log.Fatalln("please set the env variable `ELECTRICITY_MAPS_API_TOKEN`")
 	}
-	url := os.Getenv("ELECTRICITY_MAP_API_URL")
+	url := os.Getenv("ELECTRICITY_MAPS_API_URL")
 	if url != "" {
-		log.Fatalln("please set the env variable `ELECTRICITY_MAP_API_URL`")
+		log.Fatalln("please set the env variable `ELECTRICITY_MAPS_API_URL`")
 	}
 
-	c := provider.ElectricityMapConfig{
+	c := provider.ElectricityMapsConfig{
 		APIURL: url,
 		Token:  token,
 	}
-	e, err := provider.NewElectricityMap(c)
+	e, err := provider.NewElectricityMaps(c)
 	if err != nil {
 		log.Fatalln("could not make provider", err)
 	}

--- a/helm/grid-intensity-exporter/templates/deployment.yaml
+++ b/helm/grid-intensity-exporter/templates/deployment.yaml
@@ -47,14 +47,14 @@ spec:
         {{- end }}
         {{- if .Values.electricityMap }}
         {{- if .Values.electricityMap.apiToken }}
-        - name: ELECTRICITY_MAP_API_TOKEN
+        - name: ELECTRICITY_MAPS_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}
               key: apiToken
         {{- end }}
         {{- if .Values.electricityMap.apiURL }}
-        - name: ELECTRICITY_MAP_API_URL
+        - name: ELECTRICITY_MAPS_API_URL
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}

--- a/pkg/provider/carbon_intensity_uk.go
+++ b/pkg/provider/carbon_intensity_uk.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 )
@@ -44,6 +45,9 @@ func (a *CarbonIntensityUKClient) GetCarbonIntensity(ctx context.Context, locati
 	if err != nil {
 		return nil, err
 	}
+
+	log.Printf("calling %s", req.URL)
+
 	resp, err := a.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/electricity_maps.go
+++ b/pkg/provider/electricity_maps.go
@@ -91,8 +91,8 @@ func (e *ElectricityMapsClient) GetCarbonIntensity(ctx context.Context, location
 }
 
 func (e *ElectricityMapsClient) intensityURLWithZone(zone string) (string, error) {
-	zonePath := fmt.Sprintf("/carbon-intensity/latest?zone=%s", zone)
-	return buildURL(e.apiURL, zonePath)
+	zoneURL := fmt.Sprintf("/carbon-intensity/latest?zone=%s", zone)
+	return buildURL(e.apiURL, zoneURL)
 }
 
 type electricityMapsData struct {

--- a/pkg/provider/electricity_maps_test.go
+++ b/pkg/provider/electricity_maps_test.go
@@ -19,17 +19,17 @@ var MockElectricityMapResponse = `{
 	"updatedAt": "2020-01-01T00:00:01.000Z"
 }`
 
-func Test_ElectricityMap_SimpleRequest(t *testing.T) {
+func Test_ElectricityMaps_SimpleRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, MockElectricityMapResponse)
 	}))
 	defer ts.Close()
 
-	c := ElectricityMapConfig{
+	c := ElectricityMapsConfig{
 		APIURL: ts.URL,
 		Token:  "token",
 	}
-	a, err := NewElectricityMap(c)
+	a, err := NewElectricityMaps(c)
 	if err != nil {
 		t.Errorf("Could not make provider: %s", err)
 		return
@@ -44,7 +44,7 @@ func Test_ElectricityMap_SimpleRequest(t *testing.T) {
 		{
 			EmissionsType: "average",
 			MetricType:    "absolute",
-			Provider:      "ElectricityMap",
+			Provider:      "ElectricityMaps",
 			Location:      "IN-KA",
 			Units:         "gCO2e per kWh",
 			ValidFrom:     time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"net/url"
+	"path"
 	"time"
 )
 
@@ -21,7 +23,7 @@ const (
 
 	// Supported providers
 	CarbonIntensityOrgUK = "CarbonIntensityOrgUK"
-	ElectricityMap       = "ElectricityMap"
+	ElectricityMaps      = "ElectricityMaps"
 	Ember                = "Ember"
 	WattTime             = "WattTime"
 )
@@ -53,8 +55,8 @@ func GetProviderDetails() []Details {
 			URL:  "carbonintensity.org.uk",
 		},
 		{
-			Name: ElectricityMap,
-			URL:  "electricitymap.org",
+			Name: ElectricityMaps,
+			URL:  "electricitymaps.com",
 		},
 		{
 			Name: Ember,
@@ -65,4 +67,31 @@ func GetProviderDetails() []Details {
 			URL:  "watttime.org",
 		},
 	}
+}
+
+func buildURL(apiURL, relativePath string) (string, error) {
+	baseURL, err := url.Parse(apiURL)
+	if err != nil {
+		return "", err
+	}
+
+	relativeURL, err := url.Parse(relativePath)
+	if err != nil {
+		return "", err
+	}
+
+	// Safely add relative path.
+	baseURL.Path = path.Join(baseURL.Path, relativeURL.Path)
+
+	// Safely merge query strings.
+	baseQuery := baseURL.Query()
+
+	for param, values := range relativeURL.Query() {
+		for _, value := range values {
+			baseQuery.Add(param, value)
+		}
+	}
+
+	baseURL.RawQuery = baseQuery.Encode()
+	return baseURL.String(), nil
 }


### PR DESCRIPTION
Fixes https://github.com/thegreenwebfoundation/grid-intensity-go/issues/77

This PR

- Renames Electricity Map provider to Electricity Maps to match their naming.
- Fixes building URLs if the base URL has trailing slashes or not
- Minor change to log URLs when calling APIs
