### PR TITLE
Ability to pass location codes in CSV format

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -48,7 +48,7 @@ func getClient(providerName string, cacheFile string) (provider.Interface, error
 		}
 
 		password := os.Getenv(wattTimePasswordEnvVar)
-		if user == "" {
+		if password == "" {
 			return nil, fmt.Errorf("%q env var must be set", wattTimePasswordEnvVar)
 		}
 

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -27,7 +27,7 @@ const (
 )
 
 func init() {
-	exporterCmd.Flags().StringP(locationKey, "l", "", "Location code for provider")
+	exporterCmd.Flags().StringP(locationKey, "l", "", "Location codes for provider, for multiple locations separate with a comma")
 	exporterCmd.Flags().StringP(nodeKey, "n", "", "Node where the exporter is running")
 	exporterCmd.Flags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
 	exporterCmd.Flags().StringP(regionKey, "r", "", "Region where the exporter is running")

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -150,9 +151,15 @@ func NewExporter(config ExporterConfig) (*Exporter, error) {
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	result, err := e.client.GetCarbonIntensity(ctx, e.location)
-	if err != nil {
-		log.Printf("failed to get carbon intensity %#v", err)
+	var result []provider.CarbonIntensity
+	locationCodes := strings.Split(e.location, ",")
+
+	for _, locationCode := range locationCodes {
+		res, err := e.client.GetCarbonIntensity(ctx, locationCode)
+		if err != nil {
+			log.Printf("could not get carbon intensity for location %s, %#v", locationCode, err)
+		}
+		result = append(result, res...)
 	}
 
 	for _, data := range result {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,25 +103,27 @@ func runRoot() error {
 	if err != nil {
 		return fmt.Errorf("could not read config for %#q, %w", locationKey, err)
 	}
-
+	locationCodes := strings.Split(locationCode, ",")
 	var cacheFile string
 
 	switch providerName {
 	case provider.CarbonIntensityOrgUK:
-		if locationCode == "" {
-			locationCode = "UK"
+		if locationCodes[0] == "" {
+			locationCodes[0] = "UK"
 		}
-		if locationCode != "UK" {
+		// Since only UK is supported with this Provider we expect the user to only provide one location.
+		if locationCodes[0] != "UK" {
 			return fmt.Errorf("only location UK is supported")
 		}
-		viper.Set(locationKey, locationCode)
+		viper.Set(locationKey, locationCodes)
 	case provider.Ember:
-		if locationCode == "" {
-			locationCode, err = getCountryCode()
+		if len(locationCodes) == 0 {
+			// Default to the user's locale if no LocationCodes are provided
+			locationCodes[0], err = getCountryCode()
 			if err != nil {
 				return err
 			}
-			viper.Set(locationKey, locationCode)
+			viper.Set(locationKey, locationCodes)
 		}
 	case provider.WattTime:
 		homeDir, err := os.UserHomeDir()
@@ -137,16 +139,19 @@ func runRoot() error {
 		return fmt.Errorf("could not get client, %w", err)
 	}
 
-	res, err := client.GetCarbonIntensity(ctx, locationCode)
-	if err != nil {
-		return fmt.Errorf("could not get carbon intensity, %w", err)
+	var result []provider.CarbonIntensity
+	for _, locationCode := range locationCodes {
+		res, err := client.GetCarbonIntensity(ctx, locationCode)
+		if err != nil {
+			return fmt.Errorf("could not get carbon intensity for location %s, %w", locationCode, err)
+		}
+		result = append(result, res...)
 	}
 
-	bytes, err := json.MarshalIndent(res, "", "\t")
+	bytes, err := json.MarshalIndent(result, "", "\t")
 	if err != nil {
 		return fmt.Errorf("could not marshal json, %w", err)
 	}
-
 	fmt.Println(string(bytes))
 
 	err = writeConfig()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringP(locationKey, "l", "", "Location code for provider")
+	rootCmd.Flags().StringP(locationKey, "l", "", "Location codes for provider, for multiple locations separate with a comma")
 	rootCmd.Flags().StringP(providerKey, "p", provider.Ember, "Provider of carbon intensity data")
 
 	// Also support environment variables.


### PR DESCRIPTION
For both the CLI and Exporter you can now pass a comma-separated list with the `--location` param or the `GRID_INTENSITY_LOCATION` environment variable.

The response format remains unchanged as it already returned a JSON array.